### PR TITLE
fix NPE when proccessing annotations and make BeanDefinition `public` and `final`

### DIFF
--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/BeanDefinitionProcessor.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/BeanDefinitionProcessor.java
@@ -1,3 +1,6 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
 package org.terasology.gestalt.annotation.processing;
 
 import com.squareup.javapoet.ArrayTypeName;
@@ -320,6 +323,7 @@ public class BeanDefinitionProcessor extends AbstractProcessor {
             JavaFile.Builder builder = JavaFile.builder(
                 className.substring(0, className.lastIndexOf('.')),
                 TypeSpec.classBuilder(typeElement.getSimpleName().toString() + "$BeanDefinition")
+                        .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                     .superclass(ParameterizedTypeName.get(
                         ClassName.get(beanDefinitionClass),
                         TypeName.get(typeElement.asType()))

--- a/gestalt-inject/src/main/java/org/terasology/context/DefaultAnnotationValue.java
+++ b/gestalt-inject/src/main/java/org/terasology/context/DefaultAnnotationValue.java
@@ -1,10 +1,13 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
 package org.terasology.context;
+
+import com.google.common.collect.Maps;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -14,7 +17,7 @@ public class DefaultAnnotationValue<S extends Annotation> implements AnnotationV
     private String annotationName;
     private Map<String, Object> defaultValues;
     private Map<String, Object> values;
-    private Map<String, AnnotationValue[]> annotations;
+    private Map<String, AnnotationValue[]> annotations = Maps.newHashMap();
 
     public DefaultAnnotationValue(String name, Map<String, Object> values, Map<String, Object> defaultValues) {
         this(name, values, defaultValues, new AnnotationValue[]{});


### PR DESCRIPTION
fixed causes:
1.`DefaultAnnotationValue#annotations` was `null` always. it throws NPE, when try to process any annotation.
1.`BeanDefinition` was not accessable (you cannot access not public class .. blablabla), because was `package-private` make it `public`, make it `final` for faster access (JVM will not to find childs for BeanDefenition, and i sure we will don't  do childs)